### PR TITLE
Designate $options arg as being optional

### DIFF
--- a/src/stubs.php
+++ b/src/stubs.php
@@ -7,7 +7,7 @@
  * @param array $options An array of optional options, namely, the 'ignored_functions' option to pass in functions to be ignored during profiling.
  * @return null
  */
-function tideways_enable($flags = 0, array $options)
+function tideways_enable($flags = 0, array $options = [])
 {
 }
 


### PR DESCRIPTION
Bonjour :)

Currently code like:
```php
if (extension_loaded('tideways')) {
    tideways_enable(TIDEWAYS_FLAGS_CPU + TIDEWAYS_FLAGS_MEMORY);   // IDE warns about lack of second arg, $options
}
```
causes the IDE to warn that the required second arg is missing, however reflection indicates that `tideways_enable()` (version 4.1.2) has no required args:
```php
$function = new ReflectionFunction('tideways_enable');
var_dump($function->getParameters()); // [flags, options]
var_dump($function->getNumberOfRequiredParameters()); // 0
```
I'm not sure if the default value is empty array or null, as it appears reflection can't provide that info: https://bugs.php.net/bug.php?id=50798, but practically I don't think it will matter.

It would also be great if you could release a stable version on packagist, at the moment this library is tagged as `dev-master`. My understanding is to release a `stable` version you need to add a a git tag.
